### PR TITLE
Fix saut de ligne

### DIFF
--- a/core/modules/referenceletters/modules_referenceletters.php
+++ b/core/modules/referenceletters/modules_referenceletters.php
@@ -161,7 +161,7 @@ abstract class ModelePDFReferenceLetters extends CommonDocGeneratorReferenceLett
 		}
 
 		// Annule la modification de la méthode preOdfToOdf() de la class Odf (htdocs/includes/odtphp/odf.php) si on passe dans une boucle
-		$chapter_text = str_replace("<text:line-break/>", "\n", $chapter_text);
+		$chapter_text = str_replace("<text:line-break/>", "<br />", $chapter_text);
 		
 		return $chapter_text;
 	}


### PR DESCRIPTION
Pour les documents d'agefodd, utiliser un `\n` fonctionne à merveille mais pas terrible pour les documents standards (exemple avec facture)
Vu en direct chez akteos, mettre des `<br />` fonctionne partout