### PR TITLE
FIX segment key reserved found in chapter content

### DIFF
--- a/core/modules/referenceletters/modules_referenceletters.php
+++ b/core/modules/referenceletters/modules_referenceletters.php
@@ -412,9 +412,9 @@ abstract class ModelePDFReferenceLetters extends CommonDocGeneratorReferenceLett
 					continue;
 				}
 
-				$listlines = $odfHandler->setSegment($element_array);
-
 				if (strpos($chapter_text, '[!-- BEGIN') !== false) {
+					
+					$listlines = $odfHandler->setSegment($element_array);
 
 					if (! empty($object->{$element_array})) {
 


### PR DESCRIPTION
FIX segment key reserved found in chapter content : 
- if you have "lines " in chapter content after substitution it will generate an 500 error

Reproduce this error :
- in the model of your document add a field "{cust_company_name}" (for proposals)
- and try to generate a proposal for a company name whose name ending with "lines" (for example : "Collines du Nord")