### PR TITLE
FIX : GETPOST check parameter missing (none)

### DIFF
--- a/admin/admin_referenceletters.php
+++ b/admin/admin_referenceletters.php
@@ -69,8 +69,8 @@ if ($action == 'updateMask') {
 	dolibarr_set_const($db, "REF_LETTER_ADDON", $value, 'chaine', 0, '', $conf->entity);
 } else if ($action == 'setvar') {
 	dolibarr_set_const($db, "REF_LETTER_TYPEEVENTNAME", GETPOST('REF_LETTER_TYPEEVENTNAME', 'alpha'), 'chaine', 0, '', $conf->entity);
-	dolibarr_set_const($db, "REF_LETTER_PREDEF_HEADER", GETPOST('REF_LETTER_PREDEF_HEADER'), 'chaine', 0, '', $conf->entity);
-	dolibarr_set_const($db, "REF_LETTER_PREDEF_FOOTER", GETPOST('REF_LETTER_PREDEF_FOOTER'), 'chaine', 0, '', $conf->entity);
+	dolibarr_set_const($db, "REF_LETTER_PREDEF_HEADER", GETPOST('REF_LETTER_PREDEF_HEADER', 'none'), 'chaine', 0, '', $conf->entity);
+	dolibarr_set_const($db, "REF_LETTER_PREDEF_FOOTER", GETPOST('REF_LETTER_PREDEF_FOOTER','none'), 'chaine', 0, '', $conf->entity);
 } else if ($action == 'replacetemplate') {
 	define('INC_FROM_DOLIBARR', true);
 	$reinstalltemplate=true;

--- a/class/actions_referenceletters.class.php
+++ b/class/actions_referenceletters.class.php
@@ -221,7 +221,7 @@ class ActionsReferenceLetters
 
 			if ($action === 'builddoc') {
 
-				$model = GETPOST('model');
+				$model = GETPOST('model', 'none');
 
 				// Récupération de l'id du modèle
 				if (strpos($model, 'rfltr_') !== false) {
@@ -384,7 +384,7 @@ class ActionsReferenceLetters
             // Header sur la même page pour annuler le traitement standard de génération de PDF
             $field_id = 'id';
             if(get_class($object) === 'Facture') $field_id = 'facid';
-            header('location: '.$_SERVER['PHP_SELF'].'?id='.GETPOST($field_id));
+            header('location: '.$_SERVER['PHP_SELF'].'?id='.GETPOST($field_id, 'none'));
             exit;
          */
         return 1;

--- a/class/listview.class.php
+++ b/class/listview.class.php
@@ -1,20 +1,20 @@
 <?php
 /*
  EXPERIMENTAL
- 
+
  Copyright (C) 2016 ATM Consulting <support@atm-consulting.fr>
 
  This program and all files within this directory and sub directory
- is free software: you can redistribute it and/or modify it under 
- the terms of the GNU General Public License as published by the 
- Free Software Foundation, either version 3 of the License, or any 
+ is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the
+ Free Software Foundation, either version 3 of the License, or any
  later version.
- 
+
  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -50,13 +50,13 @@ class Listview
 	private function init(&$TParam)
     {
 		global $conf, $langs, $user;
-		
+
 		if(!isset($TParam['hide'])) $TParam['hide']=array();
 		if(!isset($TParam['link'])) $TParam['link']=array();
 		if(!isset($TParam['type'])) $TParam['type']=array();
 		if(!isset($TParam['orderby']['noOrder'])) $TParam['orderby']['noOrder']=array();
 		if(!isset($TParam['allow-fields-select'])) $TParam['allow-fields-select'] = 0;
-		
+
 		if(!isset($TParam['list']))$TParam['list']=array();
 		$TParam['list'] = array_merge(array(
 			'messageNothing'=>$langs->trans('ListMessageNothingToShow')
@@ -71,20 +71,20 @@ class Listview
 			,'export'=>array()
 			,'view_type'=>''
 		),$TParam['list']);
-		
+
 		if (empty($TParam['limit'])) $TParam['limit'] = array();
-		
-		$page = GETPOST('page');
+
+		$page = GETPOST('page', 'none');
 		if (!empty($page)) $TParam['limit']['page'] = $page+1; // TODO dolibarr start page at 0 instead 1
-		
+
 		$TParam['limit'] = array_merge(array('page'=>1, 'nbLine' => $conf->liste_limit, 'global'=>0), $TParam['limit']);
-		
-		if (GETPOST('sortfield'))
+
+		if (GETPOST('sortfield', 'none'))
 		{
-			$TParam['sortfield'] = GETPOST('sortfield');
-			$TParam['sortorder'] = GETPOST('sortorder');
+			$TParam['sortfield'] = GETPOST('sortfield', 'none');
+			$TParam['sortorder'] = GETPOST('sortorder', 'none');
 		}
-		
+
 		include_once DOL_DOCUMENT_ROOT.'/core/class/html.form.class.php';
 		$this->form = new Form($this->db);
 	}
@@ -112,18 +112,18 @@ class Listview
 		if(!empty($TParam['search'][$key]['table']))
 		{
 			if (!is_array($TParam['search'][$key]['table'])) $TParam['search'][$key]['table'] = array($TParam['search'][$key]['table']);
-			
+
 			foreach ($TParam['search'][$key]['table'] as $prefix_table)
 			{
-				$TPrefixe[] = $prefix_table.'.'; 
+				$TPrefixe[] = $prefix_table.'.';
 			}
 		}
-		
+
 		$TKey=array();
 		if(!empty($TParam['search'][$key]['field']))
 		{
 			if (!is_array($TParam['search'][$key]['field'])) $TParam['search'][$key]['field'] = array($TParam['search'][$key]['field']);
-			
+
 			foreach ($TParam['search'][$key]['field'] as $i => $field)
 			{
 				$prefixe = !empty($TPrefixe[$i]) ? $TPrefixe[$i] : $TPrefixe[0];
@@ -134,7 +134,7 @@ class Listview
 		{
 			$TKey[] = $TPrefixe[0].$key;
 		}
-		
+
 		return $TKey;
 	}
 
@@ -193,7 +193,7 @@ class Listview
 		// Do not use empty() function, statut 0 exist
 		if ($value == '') return false;
 		elseif($value==-1) return false;
-			
+
 		if(isset($TParam['operator'][$key]))
 		{
 			if($TParam['operator'][$key] == '<' || $TParam['operator'][$key] == '>' || $TParam['operator'][$key]=='=')
@@ -215,7 +215,7 @@ class Listview
             if(strpos($value,'%')===false) $value = '%'.$value.'%';
             $TSQLMore[]=$sKey." LIKE '".addslashes($value)."'" ;
 		}
-		
+
 		return true;
 	}
 
@@ -227,46 +227,46 @@ class Listview
      */
     private function search($sql, &$TParam)
     {
-		$ListPOST = GETPOST('Listview');
-		
-		if (!GETPOST("button_removefilter_x") && !GETPOST("button_removefilter.x") && !GETPOST("button_removefilter"))
+		$ListPOST = GETPOST('Listview', 'none');
+
+		if (!GETPOST("button_removefilter_x", 'none') && !GETPOST("button_removefilter.x", 'none') && !GETPOST("button_removefilter", 'none'))
 		{
 			foreach ($TParam['search'] as $field => $info)
 			{
 				$TsKey = $this->getSearchKey($field, $TParam);
 				$TSQLMore = array();
 				$allow_is_null = $this->getSearchNull($field,$TParam);
-				
+
 				foreach ($TsKey as $i => &$sKey)
 				{
 					$value = '';
 					if (isset($ListPOST[$this->id]['search'][$field])) $value = $ListPOST[$this->id]['search'][$field];
-					
+
 					if ($allow_is_null && !empty($ListPOST[$this->id]['search_on_null'][$field]))
 					{
 						$TSQLMore[] = $sKey.' IS NULL ';
 						$value = '';
 					}
-					
+
 					if (isset($TParam['type'][$field]) && ($TParam['type'][$field]==='date' || $TParam['type'][$field]==='datetime'))
 					{
 						$k = 'Listview_'.$this->id.'_search_'.$field;
 						if ($info['search_type'] === 'calendars')
 						{
 							$value = array();
-							
-							$timestart = dol_mktime(0, 0, 0, GETPOST($k.'_startmonth'), GETPOST($k.'_startday'), GETPOST($k.'_startyear'));
+
+							$timestart = dol_mktime(0, 0, 0, GETPOST($k.'_startmonth', 'none'), GETPOST($k.'_startday', 'none'), GETPOST($k.'_startyear', 'none'));
 							if ($timestart) $value['start'] = date('Y-m-d', $timestart);
-							
-							$timeend = dol_mktime(23, 59, 59, GETPOST($k.'_endmonth'), GETPOST($k.'_endday'), GETPOST($k.'_endyear'));
+
+							$timeend = dol_mktime(23, 59, 59, GETPOST($k.'_endmonth', 'none'), GETPOST($k.'_endday', 'none'), GETPOST($k.'_endyear', 'none'));
 							if ($timeend) $value['end'] = date('Y-m-d', $timeend);
 						}
 						else
 						{
-							$time = dol_mktime(12, 0, 0, GETPOST($k.'month'), GETPOST($k.'day'), GETPOST($k.'year'));
+							$time = dol_mktime(12, 0, 0, GETPOST($k.'month', 'none'), GETPOST($k.'day', 'none'), GETPOST($k.'year', 'none'));
 							if ($time) $value = date('Y-m-d', $time);
 						}
-						
+
 						if (!empty($value)) $this->addSqlFromTypeDate($TSQLMore, $value, $sKey);
 					}
 					else
@@ -274,14 +274,14 @@ class Listview
 						$this->addSqlFromOther($TSQLMore, $value, $TParam, $sKey, $field);
 					}
 				}
-				
+
 				if (!empty($TSQLMore))
 				{
 					$sql.=' AND ( '.implode(' OR ',$TSQLMore).' ) ';
 				}
 			}
 		}
-		
+
 		if ($sqlGROUPBY!='') $sql.=' GROUP BY '.$sqlGROUPBY;
 
 		return $sql;
@@ -295,16 +295,16 @@ class Listview
     public function render($sql, $TParam=array())
     {
 		$TField=array();
-		
+
 		$this->init($TParam);
 		$THeader = $this->initHeader($TParam);
-		
+
 		$sql = $this->search($sql,$TParam);
-		$sql = $this->order_by($sql, $TParam);		
-		
-		$this->parse_sql($THeader, $TField, $TParam, $sql);	
+		$sql = $this->order_by($sql, $TParam);
+
+		$this->parse_sql($THeader, $TField, $TParam, $sql);
 		list($TTotal, $TTotalGroup)=$this->get_total($TField, $TParam);
-		
+
 		return $this->renderList($THeader, $TField, $TTotal, $TTotalGroup, $TParam);
 	}
 
@@ -316,38 +316,38 @@ class Listview
     private function setSearch(&$THeader, &$TParam)
     {
 		global $langs, $form;
-		
+
 		if(empty($TParam['search'])) return array();
-		
+
 		$TSearch=array();
-		
+
 		$nb_search_in_bar = 0;
-		
+
 		if(!empty($TParam['search']))
 		{
 			foreach($THeader as $key => $libelle)
 			{
 				if(empty($TSearch[$key]))$TSearch[$key]='';
 			}
-		}	
-		
-		$ListPOST = GETPOST('Listview');
-		$removeFilter = (GETPOST("button_removefilter_x") || GETPOST("button_removefilter.x") || GETPOST("button_removefilter"));
+		}
+
+		$ListPOST = GETPOST('Listview', 'none');
+		$removeFilter = (GETPOST("button_removefilter_x", 'none') || GETPOST("button_removefilter.x", 'none') || GETPOST("button_removefilter", 'none'));
 		foreach($TParam['search'] as $key => $param_search)
 		{
 			$value = isset($ListPOST[$this->id]['search'][$key]) ? $ListPOST[$this->id]['search'][$key] : '';
 			if ($removeFilter) $value = '';
-			
-			$typeRecherche = (is_array($param_search) && isset($param_search['search_type'])) ? $param_search['search_type'] : $param_search;  
-			
+
+			$typeRecherche = (is_array($param_search) && isset($param_search['search_type'])) ? $param_search['search_type'] : $param_search;
+
 			if(is_array($typeRecherche))
 			{
 				$fsearch=$form->selectarray('Listview['.$this->id.'][search]['.$key.']', $typeRecherche,$value,1);
 			}
 			else if($typeRecherche==='calendar')
 			{
-				if (!$removeFilter) $value = GETPOST('Listview_'.$this->id.'_search_'.$key) ? mktime(0,0,0, (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'month'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'day'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'year') ) : '';
-				
+				if (!$removeFilter) $value = GETPOST('Listview_'.$this->id.'_search_'.$key, 'none') ? mktime(0,0,0, (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'month', 'none'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'day', 'none'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'year', 'none') ) : '';
+
 				$fsearch = $form->select_date($value, 'Listview_'.$this->id.'_search_'.$key,0, 0, 1, "", 1, 0, 1);
 			}
 			else if($typeRecherche==='calendars')
@@ -355,17 +355,17 @@ class Listview
 				$value_start = $value_end = '';
 				if (!$removeFilter)
 				{
-					$value_start = GETPOST('Listview_'.$this->id.'_search_'.$key.'_start') ? mktime(0,0,0, (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_startmonth'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_startday'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_startyear') ) : '';
-					$value_end = GETPOST('Listview_'.$this->id.'_search_'.$key.'_end') ? mktime(0,0,0, (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_endmonth'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_endday'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_endyear') ) : '';
+					$value_start = GETPOST('Listview_'.$this->id.'_search_'.$key.'_start', 'none') ? mktime(0,0,0, (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_startmonth', 'none'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_startday', 'none'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_startyear', 'none') ) : '';
+					$value_end = GETPOST('Listview_'.$this->id.'_search_'.$key.'_end', 'none') ? mktime(0,0,0, (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_endmonth', 'none'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_endday', 'none'), (int) GETPOST('Listview_'.$this->id.'_search_'.$key.'_endyear', 'none') ) : '';
 				}
-			
+
 				$fsearch = $form->select_date($value_start, 'Listview_'.$this->id.'_search_'.$key.'_start',0, 0, 1, "", 1, 0, 1)
 						 . $form->select_date($value_end, 'Listview_'.$this->id.'_search_'.$key.'_end',0, 0, 1, "", 1, 0, 1);
-				
+
 			}
 			else if(is_string($typeRecherche))
 			{
-				$fsearch=$TParam['search'][$key];	
+				$fsearch=$TParam['search'][$key];
 			}
 			else
             {
@@ -387,17 +387,17 @@ class Listview
             {
 				$label = !empty($TParam['title'][$key]) ? $TParam['title'][$key] : $key ;
 				$TParam['list']['head_search'].= '<th>'.$label.'</th>';
-//				$TParam['list']['head_search'].='<div><span style="min-width:200px;display:inline-block;">'.$label.'</span> '.$fsearch.'</div>';	
+//				$TParam['list']['head_search'].='<div><span style="min-width:200px;display:inline-block;">'.$label.'</span> '.$fsearch.'</div>';
 			}
 		}
-		
+
 		$search_button = ' <a href="#" onclick="Listview_submitSearch(this);" class="list-search-link">'.img_search().'</a>';
 
 		if(!empty($TParam['list']['head_search']))
 		{
 			$TParam['list']['head_search']='<div style="float:right;">'.$search_button.'</div>'.$TParam['list']['head_search'];
 		}
-		
+
 		if($nb_search_in_bar>0)
 		{
 			end($TSearch);
@@ -408,7 +408,7 @@ class Listview
         {
 			$TSearch=array();
 		}
-		
+
 		return $TSearch;
 	}
 
@@ -421,16 +421,16 @@ class Listview
      */
     private function get_total(&$TField, &$TParam)
     {
-		$TTotal=$TTotalGroup=array();	
-		
+		$TTotal=$TTotalGroup=array();
+
 		if(!empty($TParam['math']) && !empty($TField[0]))
 		{
 			foreach($TField[0] as $field=>$value)
 			{
-				$TTotal[$field]='';	
+				$TTotal[$field]='';
 				$TTotalGroup[$field] = '';
 			}
-		
+
 			foreach($TParam['math'] as $field=>$typeMath)
 			{
 				if(is_array($typeMath))
@@ -461,7 +461,7 @@ class Listview
 				}
 			}
 		}
-		
+
 		return array($TTotal,$TTotalGroup);
 	}
 
@@ -489,11 +489,11 @@ class Listview
     private function setExport(&$TParam, $TField, $THeader)
     {
 		global $langs;
-		
+
 		$Tab=array();
 		if(!empty($TParam['export']))
 		{
-			$token = GETPOST('token');
+			$token = GETPOST('token', 'none');
 			if(empty($token)) $token = md5($this->id.time().rand(1,9999));
 
             $_SESSION['token_list_'.$token] = gzdeflate( serialize( array(
@@ -514,9 +514,9 @@ class Listview
                     'session_name'=>session_name()
                 );
 			}
-			
+
 		}
-		
+
 		return $Tab;
 	}
 
@@ -528,12 +528,12 @@ class Listview
     private function addTotalGroup($TField, $TTotalGroup)
     {
 		global $langs;
-		
+
 		$Tab=array();
 		$proto_total_line = array();
 		$tagbase = $old_tagbase = null;
 		$addGroupLine = false;
-		
+
 		foreach($TField as $k=>&$line)
 		{
 			if(empty($proto_total_line))
@@ -542,11 +542,11 @@ class Listview
 				{
 					$proto_total_line[$field] = '';
 				}
-				$group_line = $proto_total_line;	
+				$group_line = $proto_total_line;
 			}
-			
+
 			$addGroupLine = false;
-			
+
 			$tagbase = '';
 			foreach($line as $field=>$value)
 			{
@@ -558,16 +558,16 @@ class Listview
 					$addGroupLine = true;
 				}
 			}
-			
+
 			if(!is_null($old_tagbase) && $old_tagbase!=$tagbase && $addGroupLine)
 			{
 				$Tab[] = $previous_group_line;
 			}
-			
+
 			$old_tagbase = $tagbase;
 			$previous_group_line = $group_line;
 			$group_line = $proto_total_line;
-			
+
 			$Tab[] = $line;
 		}
 
@@ -575,7 +575,7 @@ class Listview
 		{
 			$Tab[] = $previous_group_line;
 		}
-		
+
 		return $Tab;
 	}
 
@@ -590,21 +590,21 @@ class Listview
     private function renderList(&$THeader, &$TField, &$TTotal, &$TTotalGroup, &$TParam)
     {
 		global $bc;
-		
+
 		$TSearch = $this->setSearch($THeader, $TParam);
 		$TExport = $this->setExport($TParam, $TField, $THeader);
 		$TField = $this->addTotalGroup($TField,$TTotalGroup);
-		
+
 		$out = $this->getJS();
-		
+
 		$dolibarr_decalage = $this->totalRow > $this->totalRowToShow ? 1 : 0;
 		ob_start();
 		print_barre_liste($TParam['list']['title'], $TParam['limit']['page']-1, $_SERVER["PHP_SELF"], '&'.$TParam['list']['param_url'], $TParam['sortfield'], $TParam['sortorder'], '', $this->totalRowToShow+$dolibarr_decalage, $this->totalRow, $TParam['list']['image'], 0, '', '', $TParam['limit']['nbLine']);
 		$out .= ob_get_clean();
-		
-	
+
+
 		$out.= '<table id="'.$this->id.'" class="liste" width="100%"><thead>';
-			
+
 		$out.= '<tr class="liste_titre">';
 		foreach($THeader as $field => $head)
 		{
@@ -631,14 +631,14 @@ class Listview
 			$out .= getTitleFieldOfList($head['label'], 0, $_SERVER["PHP_SELF"], $search, '', $moreparam, $moreattrib, $TParam['sortfield'], $TParam['sortorder'], $prefix);
 			$out .= $head['more'];
 		}
-		
+
 		//$out .= '<th aligne="right" class="maxwidthsearch liste_titre">--</th>';
 		$out .= '</tr>';
-		
+
 		if(count($TSearch)>0)
 		{
 			$out.='<tr class="liste_titre barre-recherche">';
-			
+
 			foreach ($THeader as $field => $head)
 			{
 				if ($field === 'selectedfields')
@@ -651,12 +651,12 @@ class Listview
 					$out .= '<td class="liste_titre" '.$moreattrib.'>'.$TSearch[$field].'</td>';
 				}
 			}
-			
+
 			$out.='</tr>';
 		}
-				
+
 		$out.='</thead><tbody>';
-		
+
 		if(empty($TField))
 		{
 			if (!empty($TParam['list']['messageNothing'])) $out .= '<tr class="pair" align="center"><td colspan="'.(count($TParam['title'])+1).'">'.$TParam['list']['messageNothing'].'</td></tr>';
@@ -680,16 +680,16 @@ class Listview
 
 					$out.='</tr>';
 				}
-				
+
 				$line_number++;
 			}
-			
+
 			$out.='</tbody>';
-			
+
 			if (!empty($TParam['list']['haveTotal']))
 			{
 				$out.='<tfoot><tr class="liste_total">';
-			
+
 				foreach ($THeader as $field => $head)
 				{
 					if (isset($TTotal[$field]))
@@ -698,13 +698,13 @@ class Listview
 						$out.='<td align="right" class="'.$field.'" '.$moreattrib.'>'.price($TTotal[$field]).'</td>';
 					}
 				}
-					
+
 				$out.='</tr></tfoot>';
 			}
 		}
 
 		$out .= '</table>';
-		
+
 		return $out;
 	}
 
@@ -717,14 +717,14 @@ class Listview
     {
 		$this->typeRender = 'array';
 
-		$TField=array();	
-		
+		$TField=array();
+
 		$this->init($TParam);
 		$THeader = $this->initHeader($TParam);
-		
+
 		$this->parse_array($THeader, $TField, $TParam);
 		list($TTotal, $TTotalGroup)=$this->get_total($TField, $TParam);
-		
+
 		$this->renderList($THeader, $TField, $TTotal, $TTotalGroup, $TParam);
 	}
 
@@ -737,16 +737,16 @@ class Listview
     private function order_by($sql, &$TParam)
     {
 		global $db;
-		
+
 		if (!empty($TParam['sortfield']))
 		{
 			if(strpos($sql,'LIMIT ') !== false) list($sql, $sqlLIMIT) = explode('LIMIT ', $sql);
-			
+
 			$sql .= $db->order($TParam['sortfield'], $TParam['sortorder']);
-			
+
 			if (!empty($sqlLIMIT)) $sql .= ' LIMIT '.$sqlLIMIT;
 		}
-		
+
 		return $sql;
 	}
 
@@ -759,43 +759,43 @@ class Listview
     private function parse_array(&$THeader, &$TField, &$TParam)
     {
 		$this->totalRow = count($TField);
-		
+
 		$this->THideFlip = array_flip($TParam['hide']);
 		$this->TTotalTmp=array();
-		
+
 		if (empty($TField)) return false;
-		
+
 		foreach($TField as $row)
 		{
 			$this->set_line($TField, $TParam, $row);
 		}
 	}
 
-	
+
 	private function initHeader(&$TParam)
 	{
 		global $user,$conf;
-		
+
 		$THeader = array();
-		
+
 		$TField=$TFieldVisibility=array();
 		foreach ($TParam['title'] as $field => $value)
 		{
 			$TField[$field]=true;
 		}
-		
+
 		$contextpage=md5($_SERVER['PHP_SELF']);
 		if(!empty($TParam['allow-field-select']))
 		{
-			$selectedfields = GETPOST('Listview'.$this->id.'_selectedfields');
-			
+			$selectedfields = GETPOST('Listview'.$this->id.'_selectedfields', 'none');
+
 			if(!empty($selectedfields))
 			{
 				include_once DOL_DOCUMENT_ROOT.'/core/lib/functions2.lib.php';
 				$tabparam['MAIN_SELECTEDFIELDS_'.$contextpage] = $selectedfields;
 	    		$result=dol_set_user_param($this->db, $conf, $user, $tabparam);
 			}
-			
+
 			$tmpvar='MAIN_SELECTEDFIELDS_'.$contextpage;
 			if (! empty($user->conf->{$tmpvar}))
 			{
@@ -813,7 +813,7 @@ class Listview
 					{
 						$visible = 1;
 					}
-		            
+
 					$TFieldVisibility[$field] = array(
 						'label'=>$label
 						,'checked'=>$visible
@@ -831,7 +831,7 @@ class Listview
 						'checked'=>$visible
 					);
 				}
-			}	
+			}
 
 			$selectedfields = $this->form->multiSelectArrayWithCheckbox('Listview'.$this->id.'_selectedfields', $TFieldVisibility, $contextpage);	// This also change content of $arrayfields_0
 		}
@@ -850,12 +850,12 @@ class Listview
 				);
 			}
 		}
-		
+
 		if(!empty($selectedfields))
 		{
 			$THeader['selectedfields']['label']='<div style="float:right">'.$selectedfields.'</div>';
 		}
-		
+
 		return $THeader;
 	}
 
@@ -872,10 +872,10 @@ class Listview
 
 		$page_number = !empty($TParam['limit']['page']) ? $TParam['limit']['page'] : 1;
 		$line_per_page = !empty($TParam['limit']['nbLine']) ? $TParam['limit']['nbLine'] : $conf->liste_limit;
-		
+
 		$start = ($page_number-1) * $line_per_page;
 		$end = ($page_number* $line_per_page) -1;
-		
+
 		if($line_number>=$start && $line_number<=$end) return true;
 		else return false;
 	}
@@ -1003,7 +1003,7 @@ class Listview
 		{
 			$sql.=' LIMIT '.(int) $TParam['limit']['global'];
 		}
-		
+
 		return $sql;
 	}
 
@@ -1016,16 +1016,16 @@ class Listview
     private function parse_sql(&$THeader, &$TField, &$TParam, $sql)
     {
 		$this->sql = $this->limitSQL($sql, $TParam);
-		
+
 		$this->TTotalTmp=array();
 		$this->THideFlip = array_flip($TParam['hide']);
-		
+
 		$res = $this->db->query($this->sql);
 		if($res!==false)
 		{
 			$this->totalRow = $this->db->num_rows($res);
 			dol_syslog(get_class($this)."::parse_sql id=".$this->id." sql=".$this->sql, LOG_DEBUG);
-			
+
 			while($currentLine = $this->db->fetch_object($res))
             {
 				$this->set_line($TField, $TParam, $currentLine);
@@ -1035,5 +1035,5 @@ class Listview
         {
 			dol_syslog(get_class($this)."::parse_sql id=".$this->id." sql=".$this->sql, LOG_ERR);
 		}
-	}	
+	}
 }

--- a/class/referenceletters_tools.class.php
+++ b/class/referenceletters_tools.class.php
@@ -86,8 +86,8 @@ class RfltrTools {
 				if (is_array($line_chapter->options_text) && count($line_chapter->options_text) > 0) {
 					foreach ($line_chapter->options_text as $key => $option_text) {
 						$options[$key] = array (
-								'use_content_option' => GETPOST('use_content_option_' . $line_chapter->id . '_' . $key),
-								'text_content_option' => GETPOST('text_content_option_' . $line_chapter->id . '_' . $key)
+								'use_content_option' => GETPOST('use_content_option_' . $line_chapter->id . '_' . $key, 'none'),
+								'text_content_option' => GETPOST('text_content_option_' . $line_chapter->id . '_' . $key, 'none')
 						);
 					}
 				}
@@ -238,7 +238,7 @@ class RfltrTools {
 				// Sélection du modèle et génération du document
 				$(".id_external_model").change(function() {
 
-					var path = '<?php echo $_SERVER['PHP_SELF']; ?>' + '?id=' + <?php echo GETPOST('id'); ?> + '&model=' + $(this).attr('model') + '&action=create&id_external_model=' + $(this).val();
+					var path = '<?php echo $_SERVER['PHP_SELF']; ?>' + '?id=' + <?php echo GETPOST('id', 'none'); ?> + '&model=' + $(this).attr('model') + '&action=create&id_external_model=' + $(this).val();
 					// On récupère l'attribut name du lien présent dans la première ligne liste_titre avant celle sur laquelle on se trouve
 					lignetitre = $(this).parent().parent();
 					while(!lignetitre.hasClass('liste_titre')) {

--- a/core/massactions.inc.php
+++ b/core/massactions.inc.php
@@ -129,7 +129,7 @@ if ($massaction == 'presend')
 	include_once DOL_DOCUMENT_ROOT.'/core/class/html.formmail.class.php';
 	$formmail = new FormMail($db);
 	$formmail->withform = -1;
-	$formmail->fromtype = (GETPOST('fromtype') ? GETPOST('fromtype') : (!empty($conf->global->MAIN_MAIL_DEFAULT_FROMTYPE) ? $conf->global->MAIN_MAIL_DEFAULT_FROMTYPE : 'user'));
+	$formmail->fromtype = (GETPOST('fromtype', 'none') ? GETPOST('fromtype', 'none') : (!empty($conf->global->MAIN_MAIL_DEFAULT_FROMTYPE) ? $conf->global->MAIN_MAIL_DEFAULT_FROMTYPE : 'user'));
 
 	if ($formmail->fromtype === 'user')
 	{
@@ -145,7 +145,7 @@ if ($massaction == 'presend')
 	//$formmail->withform = 1;
 	$liste = $langs->trans("AllRecipientSelected", count($arrayofselected));
 	$formmail->withtoreadonly = 1;
-	//$formmail->withoptiononeemailperrecipient = empty($liste)?0:((GETPOST('oneemailperrecipient')=='on')?1:-1);
+	//$formmail->withoptiononeemailperrecipient = empty($liste)?0:((GETPOST('oneemailperrecipient', 'none')=='on')?1:-1);
 	$formmail->withto = empty($liste) ? (GETPOST('sendto', 'alpha') ? GETPOST('sendto', 'alpha') : array()) : $liste;
 	$formmail->withtofree = empty($liste) ? 1 : 0;
 	$formmail->withtocc = 1;

--- a/core/modules/referenceletters/pdf/pdf_rfltr_default.modules.php
+++ b/core/modules/referenceletters/pdf/pdf_rfltr_default.modules.php
@@ -105,7 +105,7 @@ class pdf_rfltr_default extends CommonDocGenerator
 		$id_model = $object->array_options['options_rfltr_model_id'];
 
 		dol_include_once('/referenceletters/class/referenceletters_tools.class.php');
-		$instances = RfltrTools::load_object_refletter($object->id, $id_model, $object, '', GETPOST('lang_id'));
+		$instances = RfltrTools::load_object_refletter($object->id, $id_model, $object, '', GETPOST('lang_id', 'none'));
 		/** @var ReferenceLettersElements $instance_letter */
 		$instance_letter = $instances[0];
 
@@ -152,7 +152,7 @@ class pdf_rfltr_default extends CommonDocGenerator
 // 		    // Header sur la même page pour annuler le traitement standard de génération de PDF
 // 		    $field_id = 'id';
 // 		    if(get_class($object) === 'Facture') $field_id = 'facid';
-// 		    header('location: '.$_SERVER['PHP_SELF'].'?id='.GETPOST($field_id)); exit;
+// 		    header('location: '.$_SERVER['PHP_SELF'].'?id='.GETPOST($field_id, 'none')); exit;
 		    return 1;
 		}
 	}

--- a/core/sendAll.inc.php
+++ b/core/sendAll.inc.php
@@ -137,7 +137,7 @@ if (($action == 'send' || ! empty($_REQUEST['sendmail'])) && ! $_POST['addfile']
 					// <img alt="" src="'.$urlwithroot.'viewimage.php?modulepart=medias&amp;entity=1&amp;file=image/ldestailleur_166x166.jpg" style="height:166px; width:166px" />
 					$message = preg_replace('/(<img.*src=")[^\"]*viewimage\.php([^\"]*)modulepart=medias([^\"]*)file=([^\"]*)("[^\/]*\/>)/', '\1' . $urlwithroot . '/viewimage.php\2modulepart=medias\3file=\4\5', $message);
 
-					$sendtobcc = GETPOST('sendtoccc');
+					$sendtobcc = GETPOST('sendtoccc', 'none');
 					// Autocomplete the $sendtobcc
 					// $autocopy can be MAIN_MAIL_AUTOCOPY_PROPOSAL_TO, MAIN_MAIL_AUTOCOPY_ORDER_TO, MAIN_MAIL_AUTOCOPY_INVOICE_TO, MAIN_MAIL_AUTOCOPY_SUPPLIER_PROPOSAL_TO...
 					if (! empty($autocopy)) {

--- a/referenceletters/background.php
+++ b/referenceletters/background.php
@@ -38,8 +38,8 @@ require_once DOL_DOCUMENT_ROOT . '/core/class/html.formfile.class.php';
 $langs->load("companies");
 $langs->load('other');
 
-$action = GETPOST('action');
-$confirm = GETPOST('confirm');
+$action = GETPOST('action', 'none');
+$confirm = GETPOST('confirm', 'none');
 $id = GETPOST('id', 'int');
 
 // Access control
@@ -110,18 +110,18 @@ if ($object->id) {
 
 	$head = referenceletterPrepareHead($object);
 	dol_fiche_head($head, 'background', $langs->trans('RefLtrBackground'), 0, dol_buildpath('/referenceletters/img/object_referenceletters.png', 1), 1);
-	
-	
+
+
 	// Construit liste des fichiers
 	$filearray = dol_dir_list($upload_dir, "files", 0, '', '\.meta$', $sortfield, (strtolower($sortorder) == 'desc' ? SORT_DESC : SORT_ASC), 1);
 	$totalsize = 0;
 	foreach ( $filearray as $key => $file ) {
 		$totalsize += $file['size'];
 	}
-	
+
 	$linkback = '<a href="' . dol_buildpath('/referenceletters/referenceletters/list.php', 1) . '">' . $langs->trans("BackToList") . '</a>';
 	print $linkback;
-	
+
 	print '<table class="border" width="100%">';
 	print '<tr>';
 	print '<td  width="20%">';
@@ -130,7 +130,7 @@ if ($object->id) {
 	print $object->title;
 	print '</td>';
 	print '</tr>';
-	
+
 	print '<tr>';
 	print '<td width="20%">';
 	print $langs->trans('RefLtrElement');
@@ -139,19 +139,19 @@ if ($object->id) {
 	print $object->displayElement();
 	print '</td>';
 	print '</tr>';
-	
+
 	// Other attributes
 	$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
-	
+
 	if (empty($reshook) && ! empty($extrafields->attribute_label)) {
 		print $object->showOptionals($extrafields);
 	}
-	
+
 	print '</table>';
 
-	//print 
+	//print
 	print info_admin($langs->trans('RefLtrBackgroundHelp'));
-	
+
 	if (empty($conf->global->MAIN_DISABLE_FPDI)) {
 		$modulepart = 'referenceletters';
 		$permission = ($user->rights->referenceletters->write);
@@ -160,9 +160,9 @@ if ($object->id) {
 	}else {
 		setEventMessages($langs->trans('MAIN_DISABLE_FPDI is on, this option cannot work, ask to your admnistrator'),null,'errors');
 	}
-	
-	
-	
+
+
+
 } else {
 	accessforbidden('', 0, 0);
 }

--- a/referenceletters/chapter.php
+++ b/referenceletters/chapter.php
@@ -82,18 +82,18 @@ $reshook = $hookmanager->executeHooks('doActions', $parameters, $object, $action
 if ($action == "add") {
 
 	$object->fk_referenceletters=$idletter;
-	$object->title = GETPOST('refltrtitle');
+	$object->title = GETPOST('refltrtitle', 'none');
 	$object->content_text = GETPOST('content_text','none');
-	$object->sort_order=GETPOST('sort_order');
+	$object->sort_order=GETPOST('sort_order', 'none');
 	$object->readonly=GETPOST('refltrreadonly','int');
 	$object->same_page=GETPOST('refltrsame_page','int');
-	$chapter_lang=GETPOST('chapter_lang');
+	$chapter_lang=GETPOST('chapter_lang', 'none');
 	if (empty($chapter_lang)) {
 		$chapter_lang=$langs->defaultlang;
 	}
 	$object->lang=$chapter_lang;
 
-	$options = GETPOST('option_text');
+	$options = GETPOST('option_text', 'none');
 	if (!empty($options)) {
 		 $option_array = explode("\r\n",$options);
 	}
@@ -113,18 +113,18 @@ if ($action == "add") {
 		setEventMessage($object->error, 'errors');
 	}
 
-	$object->title = GETPOST('refltrtitle');
+	$object->title = GETPOST('refltrtitle', 'none');
 	$object->content_text = GETPOST('content_text','none');
-	$object->sort_order=GETPOST('sort_order');
+	$object->sort_order=GETPOST('sort_order', 'none');
 	$object->readonly=GETPOST('refltrreadonly','int');
 	$object->same_page=GETPOST('refltrsame_page','int');
-	$chapter_lang=GETPOST('chapter_lang');
+	$chapter_lang=GETPOST('chapter_lang', 'none');
 	if (empty($chapter_lang)) {
 		$chapter_lang=$langs->defaultlang;
 	}
 	$object->lang=$chapter_lang;
 
-	$options = GETPOST('option_text');
+	$options = GETPOST('option_text', 'none');
 	if (!empty($options)) {
 		$option_array = explode("\r\n",$options);
 	}
@@ -135,7 +135,7 @@ if ($action == "add") {
 		$action = 'edit';
 		setEventMessage($object->error, 'errors');
 	} else {
-		$saveandstay=GETPOST('saveandstay');
+		$saveandstay=GETPOST('saveandstay', 'none');
 		if (! empty($saveandstay)) {
 			header('Location:' . dol_buildpath('/referenceletters/referenceletters/chapter.php', 1).'?id='.$id.'&action=edit');
 		} else {

--- a/referenceletters/footer.php
+++ b/referenceletters/footer.php
@@ -15,8 +15,8 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/images.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
 
-$action = GETPOST('action');
-$confirm = GETPOST('confirm');
+$action = GETPOST('action', 'none');
+$confirm = GETPOST('confirm', 'none');
 $id = GETPOST('id', 'int');
 
 // Access control
@@ -62,11 +62,11 @@ if(empty($action)) $action = 'view';
 
 if($action === 'save') {
 
-	$object->footer = GETPOST('footer');
+	$object->footer = GETPOST('footer', 'none');
 	$object->update($user);
 
 } elseif($action === 'set_custom_footer') {
-	$object->use_custom_footer = GETPOST('use_custom_footer');
+	$object->use_custom_footer = GETPOST('use_custom_footer', 'none');
 
 	//TODO Check this !
 	echo $object->update($user);
@@ -94,7 +94,7 @@ if(!empty($object->id)) {
 	$head = referenceletterPrepareHead($object);
 	dol_fiche_head($head, 'foot', $langs->trans('RefLtrFooterTab'), 0, dol_buildpath('/referenceletters/img/object_referenceletters.png', 1), 1);
 
-	print '<form name="saveFooter" method="POST" action="'.$_SERVER['PHP_SELF'].'?id='.GETPOST('id').'">';
+	print '<form name="saveFooter" method="POST" action="'.$_SERVER['PHP_SELF'].'?id='.GETPOST('id', 'none').'">';
 
 	print '<table class="border" width="100%">';
 	print '<tr>';
@@ -128,7 +128,7 @@ if(!empty($object->id)) {
 	print '</td>';
 	print '<td><input type="checkbox" name="use_custom_footer" id="use_custom_footer" value="1" '.(!empty($object->use_custom_footer) ? 'checked="checked"' : '').' />';
 	if (!empty($conf->global->REF_LETTER_PREDEF_HEADER_AND_FOOTER) && !empty($conf->global->REF_LETTER_PREDEF_FOOTER)){
-	    print '&nbsp;&nbsp;<a href="'.$_SERVER['PHP_SELF'].'?id='.GETPOST('id').'&action=predeffooter" class="button">' . $langs->trans('Fill') . '</a>';
+	    print '&nbsp;&nbsp;<a href="'.$_SERVER['PHP_SELF'].'?id='.GETPOST('id', 'none').'&action=predeffooter" class="button">' . $langs->trans('Fill') . '</a>';
 	}
 	print '</td>';
 	print '</tr>';

--- a/referenceletters/header.php
+++ b/referenceletters/header.php
@@ -15,8 +15,8 @@ require_once DOL_DOCUMENT_ROOT . '/core/lib/images.lib.php';
 require_once DOL_DOCUMENT_ROOT . '/core/class/html.formfile.class.php';
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
 
-$action = GETPOST('action');
-$confirm = GETPOST('confirm');
+$action = GETPOST('action', 'none');
+$confirm = GETPOST('confirm', 'none');
 $id = GETPOST('id', 'int');
 
 // Access control
@@ -62,11 +62,11 @@ if(empty($action)) $action = 'view';
 
 if($action === 'save') {
 
-	$object->header = GETPOST('header');
+	$object->header = GETPOST('header', 'none');
 	$object->update($user);
 
 } elseif($action === 'set_custom_header') {
-	$object->use_custom_header = GETPOST('use_custom_header');
+	$object->use_custom_header = GETPOST('use_custom_header','none');
 	echo $object->update($user);
 	exit;
 } elseif($action === 'predefheader'){
@@ -92,7 +92,7 @@ if(!empty($object->id)) {
 	$head = referenceletterPrepareHead($object);
 	dol_fiche_head($head, 'head', $langs->trans('RefLtrHeaderTab'), 0, dol_buildpath('/referenceletters/img/object_referenceletters.png', 1), 1);
 
-	print '<form name="saveHeader" method="POST" action="'.$_SERVER['PHP_SELF'].'?id='.GETPOST('id').'">';
+	print '<form name="saveHeader" method="POST" action="'.$_SERVER['PHP_SELF'].'?id='.GETPOST('id','none').'">';
 
 	print '<table class="border" width="100%">';
 	print '<tr>';
@@ -126,7 +126,7 @@ if(!empty($object->id)) {
 	print '</td>';
 	print '<td><input type="checkbox" name="use_custom_header" id="use_custom_header" value="1" '.(!empty($object->use_custom_header) ? 'checked="checked"' : '').' />';
 	if (!empty($conf->global->REF_LETTER_PREDEF_HEADER_AND_FOOTER) && !empty($conf->global->REF_LETTER_PREDEF_HEADER)){
-	    print '&nbsp;&nbsp;<a href="'.$_SERVER['PHP_SELF'].'?id='.GETPOST('id').'&action=predefheader" class="button">' . $langs->trans('Fill') . '</a>';
+	    print '&nbsp;&nbsp;<a href="'.$_SERVER['PHP_SELF'].'?id='.GETPOST('id', 'none').'&action=predefheader" class="button">' . $langs->trans('Fill') . '</a>';
 	}
 	print '</td>';
 	print '</tr>';

--- a/referenceletters/instance.php
+++ b/referenceletters/instance.php
@@ -53,7 +53,7 @@ $idletter = GETPOST('idletter', 'int');
 $confirm = GETPOST('confirm', 'alpha');
 $element_type = GETPOST('element_type', 'alpha');
 $refletterelemntid = GETPOST('refletterelemntid', 'int');
-$justinformme = GETPOST('justinformme');
+$justinformme = GETPOST('justinformme', 'none');
 
 $sortfield=GETPOST('sortfield','alpha');
 $sortorder=GETPOST('sortorder','alpha');
@@ -126,16 +126,16 @@ if ($action == 'buildoc') {
 
 		// Save data
 		$object_element->ref_int = $ref_int;
-		$object_element->title = GETPOST('title_instance');
+		$object_element->title = GETPOST('title_instance', 'none');
 		$object_element->fk_element = $object->id;
 		$object_element->element_type = $element_type;
 		$object_element->fk_referenceletters = $idletter;
 		$object_element->outputref = GETPOST('outputref', 'int');
-		$object_element->use_custom_header = GETPOST('use_custom_header');
-		$object_element->header = RfltrTools::setImgLinkToUrl(GETPOST('header'));
-		$object_element->use_custom_footer = GETPOST('use_custom_footer');
-		$object_element->footer = RfltrTools::setImgLinkToUrl(GETPOST('footer'));
-		$object_element->use_landscape_format = GETPOST('use_landscape_format');
+		$object_element->use_custom_header = GETPOST('use_custom_header', 'none');
+		$object_element->header = RfltrTools::setImgLinkToUrl(GETPOST('header', 'none'));
+		$object_element->use_custom_footer = GETPOST('use_custom_footer', 'none');
+		$object_element->footer = RfltrTools::setImgLinkToUrl(GETPOST('footer', 'none'));
+		$object_element->use_landscape_format = GETPOST('use_landscape_format', 'none');
 
 		if (empty($langs_chapter) && ! empty($conf->global->MAIN_MULTILANGS)) {
 			$langs_chapter = $object->thirdparty->default_lang;
@@ -158,8 +158,8 @@ if ($action == 'buildoc') {
 				if (is_array($line_chapter->options_text) && count($line_chapter->options_text) > 0) {
 					foreach ($line_chapter->options_text as $key => $option_text) {
 						$options[$key] = array (
-								'use_content_option' => GETPOST('use_content_option_' . $line_chapter->id . '_' . $key),
-								'text_content_option' => GETPOST('text_content_option_' . $line_chapter->id . '_' . $key)
+								'use_content_option' => GETPOST('use_content_option_' . $line_chapter->id . '_' . $key, 'none'),
+								'text_content_option' => GETPOST('text_content_option_' . $line_chapter->id . '_' . $key, 'none')
 						);
 					}
 				}
@@ -193,13 +193,13 @@ if ($action == 'buildoc') {
 			setEventMessage($object_element->error, 'errors');
 		}
 
-		$object_element->title = GETPOST('title_instance');
+		$object_element->title = GETPOST('title_instance', 'none');
 		$object_element->outputref = GETPOST('outputref','int');
-		$object_element->use_custom_header = GETPOST('use_custom_header');
-		$object_element->header = RfltrTools::setImgLinkToUrl(GETPOST('header'));
-		$object_element->use_custom_footer = GETPOST('use_custom_footer');
-		$object_element->footer = RfltrTools::setImgLinkToUrl(GETPOST('footer'));
-		$object_element->use_landscape_format = GETPOST('use_landscape_format');
+		$object_element->use_custom_header = GETPOST('use_custom_header', 'none');
+		$object_element->header = RfltrTools::setImgLinkToUrl(GETPOST('header', 'none'));
+		$object_element->use_custom_footer = GETPOST('use_custom_footer', 'none');
+		$object_element->footer = RfltrTools::setImgLinkToUrl(GETPOST('footer', 'none'));
+		$object_element->use_landscape_format = GETPOST('use_landscape_format', 'none');
 
 
 		if (! empty($conf->global->MAIN_MULTILANGS)) {
@@ -221,8 +221,8 @@ if ($action == 'buildoc') {
 				if (is_array($line_chapter->options_text) && count($line_chapter->options_text) > 0) {
 					foreach ( $line_chapter->options_text as $key => $option_text ) {
 						$options[$key] = array (
-								'use_content_option' => GETPOST('use_content_option_' . $line_chapter->id . '_' . $key),
-								'text_content_option' => GETPOST('text_content_option_' . $line_chapter->id . '_' . $key)
+								'use_content_option' => GETPOST('use_content_option_' . $line_chapter->id . '_' . $key, 'none'),
+								'text_content_option' => GETPOST('text_content_option_' . $line_chapter->id . '_' . $key, 'none')
 						);
 					}
 				}
@@ -438,7 +438,7 @@ if (! empty($idletter)) {
 			print $langs->trans('RefLtrTitle');
 			print '</td>';
 			print '<td>';
-			print '<input type="text" class="flat" name="title_instance" id="title_instance" size="30" value="' . GETPOST('title_instance') . '">';
+			print '<input type="text" class="flat" name="title_instance" id="title_instance" size="30" value="' . GETPOST('title_instance', 'none') . '">';
 			print '</td>';
 			print '</tr>';
 

--- a/referenceletters/list.php
+++ b/referenceletters/list.php
@@ -47,13 +47,13 @@ $page = intval($page);
 
 
 // Search criteria
-$search_title = GETPOST("search_title");
-$search_element_type = GETPOST("search_element_type");
+$search_title = GETPOST("search_title", 'none');
+$search_element_type = GETPOST("search_element_type", 'none');
 $search_status = GETPOST("search_status",'int');
 $search_default_doc = GETPOST("search_default_doc",'int');
 
 // Do we click on purge search criteria ?
-if (GETPOST("button_removefilter_x")) {
+if (GETPOST("button_removefilter_x", 'none')) {
 	$search_title = '';
 	$search_element_type = '';
 	$search_status=-1;

--- a/referenceletters/list_instance.php
+++ b/referenceletters/list_instance.php
@@ -43,7 +43,7 @@ if (! $user->rights->referenceletters->read)
 $langs->load("referenceletters@referenceletters");
 
 
-$action = GETPOST('action');
+$action = GETPOST('action', 'none');
 $massaction=GETPOST('massaction','alpha');
 $toselect = GETPOST('toselect', 'array');
 
@@ -55,16 +55,16 @@ $page = GETPOST('page', 'int');
 $page = intval($page);
 
 // Search criteria
-$search_ref_int = GETPOST("search_ref_int");
-$search_element_type = GETPOST("search_element_type");
-$search_title = GETPOST("search_title");
-$search_company = GETPOST("search_company");
-$search_ref = GETPOST("search_ref");
+$search_ref_int = GETPOST("search_ref_int", 'none');
+$search_element_type = GETPOST("search_element_type", 'none');
+$search_title = GETPOST("search_title", 'none');
+$search_company = GETPOST("search_company", 'none');
+$search_ref = GETPOST("search_ref", 'none');
 
 $limit = GETPOST('limit','int')?GETPOST('limit','int'):$conf->liste_limit;
 if ($limit > 0 && $limit != $conf->liste_limit) $options.='&limit='.$limit;
 // Do we click on purge search criteria ?
-if (GETPOST("button_removefilter_x")) {
+if (GETPOST("button_removefilter_x", 'none')) {
 	$search_ref_int = '';
 	$search_element_type = '';
 	$search_company = '';

--- a/referenceletters/mass_gen.php
+++ b/referenceletters/mass_gen.php
@@ -82,7 +82,7 @@ function _show_ref_letter($idletter) {
 		print $langs->trans('RefLtrTitle');
 		print '</td>';
 		print '<td>';
-		print '<input type="text" class="flat" name="title_instance" id="title_instance" size="30" value="' . GETPOST('title_instance') . '">';
+		print '<input type="text" class="flat" name="title_instance" id="title_instance" size="30" value="' . GETPOST('title_instance', 'none') . '">';
 		print '</td>';
 		print '</tr>';
 
@@ -239,7 +239,7 @@ function _list_invoice() {
 					'param_url'=>'refltrelement_type=invoice'
 			)
 			,'limit'=>array(
-					'nbLine'=>(GETPOST('limit','int') ? GETPOST('limit') : $conf->liste_limit )
+					'nbLine'=>(GETPOST('limit','int') ? GETPOST('limit', 'none') : $conf->liste_limit )
 			)
 
 	));
@@ -416,28 +416,28 @@ function _list_thirdparty()
 	$search_cti = preg_replace('/^0+/', '', preg_replace('/[^0-9]/', '', GETPOST('search_cti', 'alphanohtml'))); // Phone number without any special chars
 
 	$search_id = trim(GETPOST("search_id", "int"));
-	$search_nom = trim(GETPOST("search_nom"));
-	$search_alias = trim(GETPOST("search_alias"));
-	$search_nom_only = trim(GETPOST("search_nom_only"));
-	$search_barcode = trim(GETPOST("search_barcode"));
-	$search_customer_code = trim(GETPOST('search_customer_code'));
-	$search_supplier_code = trim(GETPOST('search_supplier_code'));
-	$search_account_customer_code = trim(GETPOST('search_account_customer_code'));
-	$search_account_supplier_code = trim(GETPOST('search_account_supplier_code'));
-	$search_town = trim(GETPOST("search_town"));
-	$search_zip = trim(GETPOST("search_zip"));
-	$search_state = trim(GETPOST("search_state"));
-	$search_region = trim(GETPOST("search_region"));
-	$search_email = trim(GETPOST('search_email'));
-	$search_phone = trim(GETPOST('search_phone'));
-	$search_url = trim(GETPOST('search_url'));
-	$search_idprof1 = trim(GETPOST('search_idprof1'));
-	$search_idprof2 = trim(GETPOST('search_idprof2'));
-	$search_idprof3 = trim(GETPOST('search_idprof3'));
-	$search_idprof4 = trim(GETPOST('search_idprof4'));
-	$search_idprof5 = trim(GETPOST('search_idprof5'));
-	$search_idprof6 = trim(GETPOST('search_idprof6'));
-	$search_vat = trim(GETPOST('search_vat'));
+	$search_nom = trim(GETPOST("search_nom", 'none'));
+	$search_alias = trim(GETPOST("search_alias", 'none'));
+	$search_nom_only = trim(GETPOST("search_nom_only", 'none'));
+	$search_barcode = trim(GETPOST("search_barcode", 'none'));
+	$search_customer_code = trim(GETPOST('search_customer_code', 'none'));
+	$search_supplier_code = trim(GETPOST('search_supplier_code', 'none'));
+	$search_account_customer_code = trim(GETPOST('search_account_customer_code', 'none'));
+	$search_account_supplier_code = trim(GETPOST('search_account_supplier_code', 'none'));
+	$search_town = trim(GETPOST("search_town", 'none'));
+	$search_zip = trim(GETPOST("search_zip", 'none'));
+	$search_state = trim(GETPOST("search_state", 'none'));
+	$search_region = trim(GETPOST("search_region", 'none'));
+	$search_email = trim(GETPOST('search_email', 'none'));
+	$search_phone = trim(GETPOST('search_phone', 'none'));
+	$search_url = trim(GETPOST('search_url', 'none'));
+	$search_idprof1 = trim(GETPOST('search_idprof1', 'none'));
+	$search_idprof2 = trim(GETPOST('search_idprof2', 'none'));
+	$search_idprof3 = trim(GETPOST('search_idprof3', 'none'));
+	$search_idprof4 = trim(GETPOST('search_idprof4', 'none'));
+	$search_idprof5 = trim(GETPOST('search_idprof5', 'none'));
+	$search_idprof6 = trim(GETPOST('search_idprof6', 'none'));
+	$search_vat = trim(GETPOST('search_vat', 'none'));
 	$search_sale = trim(GETPOST("search_sale", 'int'));
 	$search_categ_cus = trim(GETPOST("search_categ_cus", 'int'));
 	$search_categ_sup = trim(GETPOST("search_categ_sup", 'int'));
@@ -450,9 +450,9 @@ function _list_thirdparty()
 	$search_stcomm = GETPOST('search_stcomm', 'int');
 	$search_import_key = GETPOST("search_import_key", "alpha");
 
-	$type = GETPOST('type');
+	$type = GETPOST('type', 'none');
 	$optioncss = GETPOST('optioncss', 'alpha');
-	$mode = GETPOST("mode");
+	$mode = GETPOST("mode", 'none');
 
 	$diroutputmassaction = $conf->societe->dir_output.'/temp/massgeneration/'.$user->id;
 
@@ -666,7 +666,7 @@ function _list_thirdparty()
 		if ($action == 'setstcomm')
 		{
 			$object = new Client($db);
-			$result = $object->fetch(GETPOST('stcommsocid'));
+			$result = $object->fetch(GETPOST('stcommsocid', 'none'));
 			$object->stcomm_id = dol_getIdFromCode($db, GETPOST('stcomm', 'alpha'), 'c_stcomm');
 			$result = $object->update($object->id, $user);
 			if ($result < 0)
@@ -1042,9 +1042,9 @@ function _list_thirdparty()
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_param.tpl.php';
 
 // Show delete result message
-	if (GETPOST('delsoc'))
+	if (GETPOST('delsoc', 'none'))
 	{
-		setEventMessages($langs->trans("CompanyDeleted", GETPOST('delsoc')), null, 'mesgs');
+		setEventMessages($langs->trans("CompanyDeleted", GETPOST('delsoc', 'none')), null, 'mesgs');
 	}
 
 // List of mass actions available
@@ -2011,15 +2011,15 @@ function _list_contact()
 	$optioncss = GETPOST('optioncss', 'alpha');
 
 
-	$type = GETPOST("type");
-	$view = GETPOST("view");
+	$type = GETPOST("type", 'none');
+	$view = GETPOST("view", 'none');
 
 	$limit = GETPOST('limit', 'int') ? GETPOST('limit', 'int') : $conf->liste_limit;
 	$sortfield = GETPOST('sortfield', 'alpha');
 	$sortorder = GETPOST('sortorder', 'alpha');
 	$page = GETPOST('page', 'int');
 	$userid = GETPOST('userid', 'int');
-	$begin = GETPOST('begin');
+	$begin = GETPOST('begin', 'none');
 	if (!$sortorder)
 		$sortorder = "ASC";
 	if (!$sortfield)
@@ -2138,7 +2138,7 @@ function _list_contact()
 		include DOL_DOCUMENT_ROOT.'/core/actions_changeselectedfields.inc.php';
 
 		// Did we click on purge search criteria ?
-		if (GETPOST('button_removefilter_x') || GETPOST('button_removefilter.x') || GETPOST('button_removefilter')) // All tests are required to be compatible with all browsers
+		if (GETPOST('button_removefilter_x', 'none') || GETPOST('button_removefilter.x', 'none') || GETPOST('button_removefilter', 'none')) // All tests are required to be compatible with all browsers
 		{
 			$sall = "";
 			$search_id = '';

--- a/script/interface.php
+++ b/script/interface.php
@@ -6,8 +6,8 @@ require_once '../class/referenceletterschapters.class.php';
 require_once '../class/html.formreferenceletters.class.php';
 require_once '../lib/referenceletters.lib.php';
 
-$get=GETPOST('get');
-$set=GETPOST('set');
+$get=GETPOST('get', 'none');
+$set=GETPOST('set', 'none');
 
 switch ($get) {
 	default:
@@ -21,8 +21,8 @@ switch ($set) {
             ,'saved' => 0
             ,'message' => ''
         );
-	    //$object_id = GETPOST('object_id');
-	    $roworder  = GETPOST('roworder');
+	    //$object_id = GETPOST('object_id', 'none');
+	    $roworder  = GETPOST('roworder', 'none');
 
 	    $TOrder = explode(',', $roworder);
 	    if(is_array($TOrder)){
@@ -53,8 +53,8 @@ switch ($set) {
 
 		break;
 	case 'content':
-	    $id=GETPOST('id');
-	    $type=GETPOST('type');
+	    $id=GETPOST('id', 'none');
+	    $type=GETPOST('type', 'none');
 	    $content=GETPOST('content','none');
 	    $Tjson = array(
 	        'status' => 0


### PR DESCRIPTION
A partir de la v12 le paramètre check de la fonction GETPOST est alphanohtml par défaut ce qui fait que tous nos inputs ayant une balise html sont vidés.
Je force donc tous les GETPOST qui n'avaient pas de param à none. (j'ai utilisé un refactoring de masse, merci flo :D)