### PR TITLE
FIX html encode

### DIFF
--- a/core/modules/referenceletters/modules_referenceletters.php
+++ b/core/modules/referenceletters/modules_referenceletters.php
@@ -468,7 +468,7 @@ abstract class ModelePDFReferenceLetters extends CommonDocGeneratorReferenceLett
 								$oldline = $listlines->xml;
 								foreach ($tmparray as $key => $val) {
 									try {
-										$listlines->setVars($key, $val, false, 'UTF-8');
+										$listlines->setVars($key, $val, true, 'UTF-8');
 									} catch (OdfException $e) {
 									} catch (SegmentException $e) {
 									}


### PR DESCRIPTION
FIX html encode
- if in your description lines you have "<" or ">" characters
- when you want to generate the document with lines, this line disapear (is not written)