### PR TITLE
2.7 tkda020165 fix write custom agefodd fiche pedago

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 English Reference Letters ChangeLog
 
 
+***** ChangeLog for 2.7.1 compared to 2.7.0 *****
+-FIX : Generate "Fiche Pedago" custom for an agefodd session
+
 ***** ChangeLog for 2.7.0 compared to 2.6.4 *****
 -New : Add idprof1 and idprof2 tag helper
 

--- a/core/modules/modReferenceLetters.class.php
+++ b/core/modules/modReferenceLetters.class.php
@@ -61,7 +61,7 @@ class modReferenceLetters extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module ReferenceLetters";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '2.7.0';
+		$this->version = '2.7.1';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/core/modules/referenceletters/pdf/pdf_rfltr_agefodd.modules.php
+++ b/core/modules/referenceletters/pdf/pdf_rfltr_agefodd.modules.php
@@ -65,6 +65,7 @@ class pdf_rfltr_agefodd extends ModelePDFReferenceLetters
 	 * @param string $file file path to save
 	 * @param string $obj_agefodd_convention convention object
 	 * @param string $socid socid
+	 * @param int $courrier id session
 	 * @return int 1=OK, 0=KO
 	 */
 	function write_file_custom_agefodd($id_object, $id_model, $outputlangs, $file, $obj_agefodd_convention = '', $socid = '', $courrier = '') {
@@ -91,11 +92,6 @@ class pdf_rfltr_agefodd extends ModelePDFReferenceLetters
 			}
 
 			$id_object= $agf_session->id;
-
-			$object_modules = new Agefoddformationcataloguemodules($this->db);
-			$result = $object_modules->fetchAll('ASC', 'sort_order', 0, 0, array(
-				't.fk_formation_catalogue' => $id
-			));
 		}
 
 		// Chargement du modèle utilisé
@@ -377,7 +373,7 @@ class pdf_rfltr_agefodd extends ModelePDFReferenceLetters
 						'instance_letter' => $instance_letter
 				);
 				global $action;
-				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+//				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
 				if (! empty($conf->global->MAIN_UMASK))
 					@chmod($file, octdec($conf->global->MAIN_UMASK));

--- a/core/modules/referenceletters/pdf/pdf_rfltr_agefodd.modules.php
+++ b/core/modules/referenceletters/pdf/pdf_rfltr_agefodd.modules.php
@@ -67,10 +67,36 @@ class pdf_rfltr_agefodd extends ModelePDFReferenceLetters
 	 * @param string $socid socid
 	 * @return int 1=OK, 0=KO
 	 */
-	function write_file_custom_agefodd($id_object, $id_model, $outputlangs, $file, $obj_agefodd_convention = '', $socid = '') {
+	function write_file_custom_agefodd($id_object, $id_model, $outputlangs, $file, $obj_agefodd_convention = '', $socid = '', $courrier = '') {
 		global $db, $user, $langs, $conf, $mysoc, $hookmanager;
 
 		dol_include_once('/referenceletters/class/referenceletters_tools.class.php');
+		dol_include_once('/referenceletters/class/referenceletters.class.php');
+
+		//ajout pansement pour le ticket #DA020165 : la fonction ne gérait pas le cas où "id_object" est l'id d'une formation
+		//TODO : gérer plus proprement le cas d'une formation en valeur du paramètre "$id_object" et uniformiser avec les différentes fonction whrite_file() comme celles du fichier pdf_fiche_pedago_modules.php
+
+		$object_refletter = new Referenceletters($db);
+		$object_refletter->fetch($id_model);
+
+		if ($object_refletter->element_type == 'rfltr_agefodd_fiche_pedago') {
+			$id = $id_object;
+			$agf = new Formation($db);
+			$agf->fetch($id);
+
+			// Vilain hack si !empty($courrier) alors c'est un id de session
+			$agf_session = new Agsession($db);
+			if (! empty($courrier)) {
+				$agf_session->fetch($courrier);
+			}
+
+			$id_object= $agf_session->id;
+
+			$object_modules = new Agefoddformationcataloguemodules($this->db);
+			$result = $object_modules->fetchAll('ASC', 'sort_order', 0, 0, array(
+				't.fk_formation_catalogue' => $id
+			));
+		}
 
 		// Chargement du modèle utilisé
 		$tmpTab = RfltrTools::load_object_refletter($id_object, $id_model, $obj_agefodd_convention, $socid, $outputlangs->defaultlang);

--- a/core/modules/referenceletters/pdf/pdf_rfltr_agefodd.modules.php
+++ b/core/modules/referenceletters/pdf/pdf_rfltr_agefodd.modules.php
@@ -373,7 +373,7 @@ class pdf_rfltr_agefodd extends ModelePDFReferenceLetters
 						'instance_letter' => $instance_letter
 				);
 				global $action;
-//				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
+				$reshook = $hookmanager->executeHooks('afterPDFCreation', $parameters, $this, $action); // Note that $action and $object may have been modified by some hooks
 
 				if (! empty($conf->global->MAIN_UMASK))
 					@chmod($file, octdec($conf->global->MAIN_UMASK));


### PR DESCRIPTION
J'ai repris le même bout de code que dans la fonction whrite_file du fichier pdf_fiche_pedago.modules.php sauf que j'ai modifié la condition "if(!is_object($id_object))" par "if ($object_refletter->element_type == 'rfltr_agefodd_fiche_pedago')" car c'est toujours un id qui est passé dans le paramètre "id_object" même quand c'est une session...

Correction la plus rapide, le reste demande une grosse partie refonte et pas le temps au support.