### PR TITLE
FIX : Specify condition Agefodd subsitution keys

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 English Reference Letters ChangeLog
 
 ***** ChangeLog for 2.0 compared to 1.9 *****
+-FIX : Specify the condition that allows the use of agefodd substitution keys only in the case of an agefodd pdf
 -New : Add mass generation for invoice model letters
 
 ***** ChangeLog for 1.9 compared to 1.8 *****

--- a/core/modules/modReferenceLetters.class.php
+++ b/core/modules/modReferenceLetters.class.php
@@ -61,7 +61,7 @@ class modReferenceLetters extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module ReferenceLetters";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '2.6.4';
+		$this->version = '2.6.5';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/core/modules/referenceletters/modules_referenceletters.php
+++ b/core/modules/referenceletters/modules_referenceletters.php
@@ -437,7 +437,7 @@ abstract class ModelePDFReferenceLetters extends CommonDocGeneratorReferenceLett
 
 						foreach ( $object->{$element_array} as $line ) {
 
-							if (method_exists($this, 'get_substitutionarray_lines_agefodd')) {
+							if (method_exists($this, 'get_substitutionarray_lines_agefodd') && strpos(get_class($this), 'agefodd') !== false) {
 								$tmparray = $this->get_substitutionarray_lines_agefodd($line, $this->outputlangs, false);
 							} else {
 								$tmparray = $this->get_substitutionarray_lines($line, $this->outputlangs, false);


### PR DESCRIPTION
# FIX

cf. DA020580
Specify the condition that allows the use of Agefodd substitution keys only in the case of an Agefodd PDF