### PR TITLE
PULLUP 2.7 : FIX Specify condition Agefodd substitution keys

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@ English Reference Letters ChangeLog
 
 
 ***** ChangeLog for 2.0 compared to 1.9 *****
+-FIX : Specify the condition that allows the use of agefodd substitution keys only in the case of an agefodd pdf
 -New : Add mass generation for invoice model letters
 -FIX : V13 compatibility add newToken to some triggers links [2021-03-03]
 

--- a/core/modules/referenceletters/modules_referenceletters.php
+++ b/core/modules/referenceletters/modules_referenceletters.php
@@ -437,7 +437,7 @@ abstract class ModelePDFReferenceLetters extends CommonDocGeneratorReferenceLett
 
 						foreach ( $object->{$element_array} as $line ) {
 
-							if (method_exists($this, 'get_substitutionarray_lines_agefodd')) {
+							if (method_exists($this, 'get_substitutionarray_lines_agefodd') && strpos(get_class($this), 'agefodd') !== false) {
 								$tmparray = $this->get_substitutionarray_lines_agefodd($line, $this->outputlangs, false);
 							} else {
 								$tmparray = $this->get_substitutionarray_lines($line, $this->outputlangs, false);


### PR DESCRIPTION
# FIX

cf. DA020580
Specify the condition that allows the use of Agefodd substitution keys only in the case of an Agefodd PDF

PR d'origine : https://github.com/ATM-Consulting/dolibarr_module_referenceletters/pull/95