### PR TITLE
Fix 2.9 select_salesrepresentatives() value for "no choice" is -1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ## Version 2.9 - 14/06/2021
 
+- FIX : In v14, select_salesrepresentatives uses -1 as empty value, sql filters adjusted accordingly *08/09/2021* - 2.9.4 
 - FIX : Change default rights to 0 *01/07/2021* - 2.9.3
 - FIX : Compatibility V13 *17/05/2021* - 2.9.2
 - FIX - Compatibility V14 : Edit the descriptor: family - *2021-06-10* - 2.9.1

--- a/core/modules/modReferenceLetters.class.php
+++ b/core/modules/modReferenceLetters.class.php
@@ -62,7 +62,7 @@ class modReferenceLetters extends DolibarrModules
 		$this->description = "Description of module ReferenceLetters";
 		// Possible values for version are: 'development', 'experimental' or version
 
-		$this->version = '2.9.3';
+		$this->version = '2.9.4';
 
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)

--- a/referenceletters/mass_gen.php
+++ b/referenceletters/mass_gen.php
@@ -912,7 +912,7 @@ function _list_thirdparty()
 		$sql .= " AND s.status = ".$db->escape($search_status);
 	if (!empty($conf->barcode->enabled) && $search_barcode)
 		$sql .= natural_search("s.barcode", $search_barcode);
-	if ($search_type_thirdparty)
+	if ($search_type_thirdparty > 0)
 		$sql .= " AND s.fk_typent IN (".$search_type_thirdparty.')';
 	if ($search_levels)
 		$sql .= " AND s.fk_prospectlevel IN (".$search_levels.')';
@@ -1020,7 +1020,7 @@ function _list_thirdparty()
 		$param .= '&search_idprof6='.urlencode($search_idprof6);
 	if ($search_vat != '')
 		$param .= '&search_vat='.urlencode($search_vat);
-	if ($search_type_thirdparty != '')
+	if ($search_type_thirdparty != '' && $search_type_thirdparty > 0)
 		$param .= '&search_type_thirdparty='.urlencode($search_type_thirdparty);
 	if ($search_type != '')
 		$param .= '&search_type='.urlencode($search_type);
@@ -1246,7 +1246,7 @@ function _list_thirdparty()
 	if (!empty($arrayfields['typent.code']['checked']))
 	{
 		print '<td class="liste_titre maxwidthonsmartphone" align="center">';
-		print $form->selectarray("search_type_thirdparty", $formcompany->typent_array(0), $search_type_thirdparty, 0, 0, 0, '', 0, 0, 0, (empty($conf->global->SOCIETE_SORT_ON_TYPEENT) ? 'ASC' : $conf->global->SOCIETE_SORT_ON_TYPEENT));
+		print $form->selectarray("search_type_thirdparty", $formcompany->typent_array(0), $search_type_thirdparty, 1, 0, 0, '', 0, 0, 0, (empty($conf->global->SOCIETE_SORT_ON_TYPEENT) ? 'ASC' : $conf->global->SOCIETE_SORT_ON_TYPEENT));
 		print '</td>';
 	}
 	if (!empty($arrayfields['s.email']['checked']))

--- a/referenceletters/mass_gen.php
+++ b/referenceletters/mass_gen.php
@@ -799,7 +799,7 @@ function _list_thirdparty()
 	$sql .= " state.code_departement as state_code, state.nom as state_name,";
 	$sql .= " region.code_region as region_code, region.nom as region_name";
 // We'll need these fields in order to filter by sale (including the case where the user can only see his prospects)
-	if ($search_sale)
+	if ($search_sale && $search_sale > 0)
 		$sql .= ", sc.fk_soc, sc.fk_user";
 // We'll need these fields in order to filter by categ
 	if ($search_categ_cus)
@@ -827,7 +827,7 @@ function _list_thirdparty()
 		$sql .= ' LEFT JOIN '.MAIN_DB_PREFIX."categorie_fournisseur as cs ON s.rowid = cs.fk_soc"; // We'll need this table joined to the select in order to filter by categ
 	$sql .= " ,".MAIN_DB_PREFIX."c_stcomm as st";
 // We'll need this table joined to the select in order to filter by sale
-	if ($search_sale || (!$user->rights->societe->client->voir && !$socid))
+	if (($search_sale && $search_sale > 0) || (!$user->rights->societe->client->voir && !$socid))
 		$sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 	$sql .= " WHERE s.fk_stcomm = st.id";
 	$sql .= " AND s.entity IN (".getEntity('societe').")";
@@ -835,11 +835,11 @@ function _list_thirdparty()
 		$sql .= " AND s.rowid = sc.fk_soc AND sc.fk_user = ".$user->id;
 	if ($socid)
 		$sql .= " AND s.rowid = ".$socid;
-	if ($search_sale)
+	if ($search_sale && $search_sale > 0)
 		$sql .= " AND s.rowid = sc.fk_soc";		// Join for the needed table to filter by sale
 	if (!$user->rights->fournisseur->lire)
 		$sql .= " AND (s.fournisseur <> 1 OR s.client <> 0)";	// client=0, fournisseur=0 must be visible
-	if ($search_sale)
+	if ($search_sale && $search_sale > 0)
 		$sql .= " AND sc.fk_user = ".$db->escape($search_sale);
 	if ($search_categ_cus > 0)
 		$sql .= " AND cc.fk_categorie = ".$db->escape($search_categ_cus);


### PR DESCRIPTION
Pareil avec selectarray (sauf que pour selectarray c'est déjà le cas depuis 5 ans alors que pour select_salesrepresentatives, c’est uniquement depuis la v14).
