### PR TITLE
FIX : Anomalie affichage pdf mise en forme

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## Version 2.9 - 14/06/2021
 
+- FIX : Affichage sur des documents généré docedit qui ne se faisait pas a cause de mise en forme <strong> - *13/12/2021* - 2.9.5
 - FIX : In v14, select_salesrepresentatives uses -1 as empty value, sql filters adjusted accordingly *08/09/2021* - 2.9.4 
 - FIX : Change default rights to 0 *01/07/2021* - 2.9.3
 - FIX : Compatibility V13 *17/05/2021* - 2.9.2

--- a/class/commondocgeneratorreferenceletters.class.php
+++ b/class/commondocgeneratorreferenceletters.class.php
@@ -631,7 +631,7 @@ class CommonDocGeneratorReferenceLetters extends CommonDocGenerator
 //		$resarray['line_fin_desciption'] = str_replace('<br />', "\n", str_replace('<BR>', "\n", $line->description));
 
 		//strip_tags permet de supprimer les balises HTML et PHP d'une chaine, la mise en forme faisait disparaître une partie du pdf de convention docedit
-        $resarray['line_fin_desciption'] = strip_tags($line->description, "<br><p><ul><ol><li><span><div><tr><td>");
+        $resarray['line_fin_desciption'] = strip_tags($line->description, "<br><p><ul><ol><li><span><div><tr><td><th><table>");
 //		$resarray['line_fin_desciption_light'] = $line->form_label;
 		$resarray['line_fin_desciption_light_short'] = $line->form_label_short;
 		$resarray['line_fin_qty'] = $line->qty;

--- a/class/commondocgeneratorreferenceletters.class.php
+++ b/class/commondocgeneratorreferenceletters.class.php
@@ -629,8 +629,10 @@ class CommonDocGeneratorReferenceLetters extends CommonDocGenerator
 
 		// Substitutions tableau des élément financier :
 //		$resarray['line_fin_desciption'] = str_replace('<br />', "\n", str_replace('<BR>', "\n", $line->description));
-        $resarray['line_fin_desciption'] = $line->description;
-		$resarray['line_fin_desciption_light'] = $line->form_label;
+
+		//strip_tags permet de supprimer les balises HTML et PHP d'une chaine, la mise en forme faisait disparaître une partie du pdf de convention docedit
+        $resarray['line_fin_desciption'] = strip_tags($line->description, "<br><p><ul><ol><li><span><div><tr><td>");
+//		$resarray['line_fin_desciption_light'] = $line->form_label;
 		$resarray['line_fin_desciption_light_short'] = $line->form_label_short;
 		$resarray['line_fin_qty'] = $line->qty;
 		$resarray['line_fin_tva_tx'] = vatrate($line->tva_tx, 1);

--- a/core/modules/modReferenceLetters.class.php
+++ b/core/modules/modReferenceLetters.class.php
@@ -61,7 +61,7 @@ class modReferenceLetters extends DolibarrModules
 		// (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module ReferenceLetters";
 		// Possible values for version are: 'development', 'experimental' or version
-		$this->version = '2.9.4';
+		$this->version = '2.9.5';
 		// Key used in llx_const table to save module status enabled/disabled
 		// (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);

--- a/lib/referenceletters.lib.php
+++ b/lib/referenceletters.lib.php
@@ -145,7 +145,7 @@ function pdf_getInstance_refletters($object, $instance_letter, &$model, $format 
 	dol_include_once('/referenceletters/class/TCPDFReferenceletters.class.php');
 
 	if ((! file_exists(TCPDF_PATH . 'tcpdf.php') && ! class_exists('TCPDFRefletters')) && ! empty($conf->global->MAIN_USE_FPDF)) {
-		print 'TCPDF Must be use for this module forget TCPDI or FPDF or other PDF class, plaese contact your admnistrator';
+		print 'TCPDF Must be use for this module forget TCPDI or FPDF or other PDF class, please contact your admnistrator';
 		exit();
 	}
 


### PR DESCRIPTION
# FIX

Affichage sur des documents généré docedit qui ne se faisait pas a cause de mise en forme de la balise strong.
La méthode utilisée est loin d'être la meilleure mais est efficace compte tenu du temps alloué.

La bonne méthode serait la suivante à mon avis: 

DocEdit utilise pour le templating des méthodes du cœur qui sont prévues pour traiter de l'ODT. Ces méthodes font le templating, mais elles font en plus une conversion du formatage HTML en formatage ODT. La conversion elle-même est un peu pourrie, mais le vrai problème n’est pas là, le problème, c'est qu'il ne faut pas faire de conversion du tout pour passer ça à TCPDF. TCPDF sait traiter du HTML, mais pas de l’ODT.
Donc la vraie solution serait de virer de DocEdit toutes les dépendances à la lib ODT du cœur et de créer une lib à lui. 