### PR TITLE
Erreur condition modèle existant

### DIFF
--- a/class/actions_referenceletters.class.php
+++ b/class/actions_referenceletters.class.php
@@ -309,7 +309,7 @@ class ActionsReferenceLetters
             }
 
             // La recherche n'a pas été fructueuse : on rend la main à la génération par défaut
-            if (empty($result) || ! is_array($staticRefLtr) || empty($staticRefLtr->lines))
+            if (empty($result) || ! is_array($staticRefLtr->lines) || empty($staticRefLtr->lines))
             {
                 return 0;
             }


### PR DESCRIPTION
Condition erronée entrainant dans certains cas la non utilisation comme document par défaut d'un modèle DocEdit