### PR TITLE
FIX DA025424 incompatibilité avec Agefodd 7

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ## Release 2.21 - 13/05/2024
 
+- FIX : DA025424 incompatibilité avec Agefodd 7 - *26/08/2024* - 2.21.5
 - FIX : Retour sécuridis BUG enregeistrement PDF lié à PropalHistory et son changement de ref propal - *14/06/2024* - 2.21.4
 - FIX : DA025049 Erreur d'affichage sur l'onglet modéle de document sur fiche commande fournisseur - *12/06/2024* - 2.21.3
 - FIX : Clés manquantes : financeurs et financeur_alternatif - *05/06/2024* - 2.21.2

--- a/class/referenceletters_tools.class.php
+++ b/class/referenceletters_tools.class.php
@@ -182,8 +182,12 @@ class RfltrTools {
 			$object = new $object_refletter->element_type_list['rfltr_agefodd_formation']['objectclass']($db);
 			$object->fetch($fk_training);
 		}
-		// on load les informations de l'object
-		$object->load_all_data_agefodd($object_refletter, $socid, $obj_agefodd_convention, false, $outputlangs);
+		// on load les informations de l'object (la méthode n'a pas le même nom selon la version d'Agefodd)
+		$agefoddInfoLoader = 'load_all_data_agefodd';
+		if (! method_exists($object, $agefoddInfoLoader)) {
+			$agefoddInfoLoader = 'load_all_data_agefodd_session';
+		}
+		$object->$agefoddInfoLoader($object_refletter, $socid, $obj_agefodd_convention, false, $outputlangs);
 
 		return $object;
 

--- a/core/modules/modReferenceLetters.class.php
+++ b/core/modules/modReferenceLetters.class.php
@@ -63,7 +63,7 @@ class modReferenceLetters extends DolibarrModules
 		// Possible values for version are: 'development', 'experimental' or version
 
 
-		$this->version = '2.21.4';
+		$this->version = '2.21.5';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \referenceletters\TechATM::getLastModuleVersionUrl($this);


### PR DESCRIPTION
Une méthode a été renommée dans Agefodd 8. DocEdit a été modifié en conséquence, mais cette modif casse la compatibilité avec Agefodd 7 et ça provoque une fatal lors de la génération des documents DocEdit dans Agefodd.